### PR TITLE
BottomSheet: ensure full width

### DIFF
--- a/src/components/BottomSheet/BottomSheet.js
+++ b/src/components/BottomSheet/BottomSheet.js
@@ -19,6 +19,7 @@ export default class BottomSheet extends Component {
         position: 'fixed',
         zIndex: 1300,
         left: 0,
+        right: 0,
         top: 0,
         backgroundColor: 'rgba(0,0,0,0.2)',
         transition: 'opacity 400ms cubic-bezier(0.4, 0, 0.2, 1)',


### PR DESCRIPTION
Ensure the BottomSheet is full width by setting right to 0,
as done in e.g. https://material.angularjs.org/latest/demo/bottomSheet